### PR TITLE
Bugfix/package name from tar whl

### DIFF
--- a/pips3/base.py
+++ b/pips3/base.py
@@ -221,6 +221,26 @@ class PipS3:
                                   ContentType="text/html")
 
 
+def get_package_name(upload_file: str) -> str:
+    """determine the package name from the artifacts to be uploaded. According to pypi,
+    if upload_file is a tar.gz, then the package name is already canonical.
+    if upload_file is a whl, then we need to replace _ with -.
+    See tests for examples.
+
+    Args:
+        upload_file (str): path to the artifacts, tar.gz or whl
+
+    Returns:
+        str: package name
+    """
+    stem = os.path.basename(upload_file)
+    splitted = stem.split("-")
+    if upload_file.endswith(".gz"):
+        return "-".join(splitted[:-1]) # the last one is version
+    # else is "whl"
+    return splitted[0].replace('_', '-')
+
+
 def publish_packages(endpoint: str,
                      bucket: str,
                      public: bool = False,
@@ -243,8 +263,7 @@ def publish_packages(endpoint: str,
         # Get the package name
         if package_name is None:
 
-            package_name = os.path.basename(upload_file).split('-')[0]
-            package_name = package_name.replace('_', '-')
+            package_name = get_package_name(upload_file)
 
         uploader.upload_package(upload_file, package_name, public,
                                 owner_full_control)

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@
 # -*- coding: utf-8 -*-
 """The setup script."""
 
-import versioneer
 from setuptools import find_packages, setup
+
+import versioneer
 
 with open('README.md') as readme_file:
     long_description = readme_file.read()
@@ -20,7 +21,8 @@ setup_requirements = [
 
 test_requirements = [
     'pytest>=6.1.1',
-    'pytest-cov>=20.10.1',
+    'pytest-cov>=2.10.1',
+    'moto>=1.3.16',
 ]
 
 setup(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,6 +10,7 @@ import pytest
 from moto import mock_s3
 
 from pips3 import PipS3, publish_packages
+from pips3.base import get_package_name
 from pips3.exceptions import PackageExistsException
 
 ENDPOINT_URL = "http://localhost:9000"
@@ -246,3 +247,14 @@ def test_publish_packages(files_mock):
 </html>"""
 
     assert index == expected_index
+
+
+@pytest.mark.parametrize("upload_file,package_name", [
+    ("cdk_remote_stack-0.1.186-py3-none-any.whl", "cdk-remote-stack"),
+    ("cdk-remote-stack-0.1.186.tar.gz", "cdk-remote-stack"),
+    ("ipyxt-0.0.1.tar.gz", "ipyxt"),
+    ("scikit_learn-1.0.1-cp37-cp37m-macosx_10_13_x86_64.whl", "scikit-learn"),
+    ("scikit-learn-1.0.1.tar.gz", "scikit-learn")
+])
+def test_get_package_name(upload_file: str, package_name: str):
+    assert get_package_name(upload_file) == package_name


### PR DESCRIPTION
Hey Ben & Carl,

Please have a look at my PR, which fixes the package name issues when dealing with `tar.gz` and `whl`. As was shown in pypi, for source code `tar.gz`, it already uses the right package name and for `whl`, it uses underscores (which needs to be transformed into dash). Please see the tests which should hopefully cover all the cases.